### PR TITLE
Add `NavigationPicker` as an alternative `Picker`

### DIFF
--- a/RoutineJournalUI/NavigationPicker/EnvironmentValues+navigationPickerOptionPosition.swift
+++ b/RoutineJournalUI/NavigationPicker/EnvironmentValues+navigationPickerOptionPosition.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+private struct NavigationPickerOptionPositionEnvironmentKey: EnvironmentKey {
+  static let defaultValue = NavigationPickerOptionPosition.destination
+}
+
+extension EnvironmentValues {
+  public var navigationPickerOptionPosition: NavigationPickerOptionPosition {
+    get {
+      self[NavigationPickerOptionPositionEnvironmentKey.self]
+    }
+    set {
+      self[NavigationPickerOptionPositionEnvironmentKey.self] = newValue
+    }
+  }
+}

--- a/RoutineJournalUI/NavigationPicker/NavigationPicker+Item.swift
+++ b/RoutineJournalUI/NavigationPicker/NavigationPicker+Item.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+extension NavigationPicker {
+  public struct Item: View {
+    public let active: Binding<Bool>
+    public let selection: Binding<SelectionValue>
+    public let option: Option
+
+    public var selected: Bool {
+      option.id == selection.wrappedValue
+    }
+
+    public var body: some View {
+      Button(
+        action: {
+          select()
+          close()
+        },
+        label: {
+          HStack(spacing: .zero) {
+            option.content
+              .foregroundColor(Color.label)
+              .environment(\.navigationPickerOptionPosition, .destination)
+            if selected {
+              Spacer()
+              Image(systemName: "checkmark")
+                .font(.headline)
+            }
+          }
+        }
+      )
+    }
+
+    public init(
+      active: Binding<Bool>,
+      selection: Binding<SelectionValue>,
+      option: Option
+    ) {
+      self.active = active
+      self.selection = selection
+      self.option = option
+    }
+
+    private func select() {
+      selection.wrappedValue = option.id
+    }
+
+    private func close() {
+      active.wrappedValue = false
+    }
+  }
+}

--- a/RoutineJournalUI/NavigationPicker/NavigationPicker+Label.swift
+++ b/RoutineJournalUI/NavigationPicker/NavigationPicker+Label.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+extension NavigationPicker {
+  public struct Label: View {
+    public let title: String
+    public let selection: Binding<SelectionValue>
+    public let options: [Option]
+
+    public var selected: Option? {
+      options.first { option in
+        option.id == selection.wrappedValue
+      }
+    }
+
+    public var body: some View {
+      HStack(spacing: .zero) {
+        Text(title)
+        if let selected {
+          Spacer()
+          selected.content
+            .foregroundColor(Color.systemGray)
+            .environment(\.navigationPickerOptionPosition, .label)
+        }
+      }
+    }
+
+    public init(
+      title: String,
+      selection: Binding<SelectionValue>,
+      options: [Option]
+    ) {
+      self.title = title
+      self.selection = selection
+      self.options = options
+    }
+  }
+}

--- a/RoutineJournalUI/NavigationPicker/NavigationPicker+Option.swift
+++ b/RoutineJournalUI/NavigationPicker/NavigationPicker+Option.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+extension NavigationPicker {
+  public struct Option: Identifiable {
+    public let id: SelectionValue
+    public let content: Content
+
+    public init(id: SelectionValue, @ViewBuilder content: () -> Content) {
+      self.id = id
+      self.content = content()
+    }
+  }
+}

--- a/RoutineJournalUI/NavigationPicker/NavigationPicker.swift
+++ b/RoutineJournalUI/NavigationPicker/NavigationPicker.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+public struct NavigationPicker<SelectionValue, Content>: View
+where SelectionValue: Hashable, Content: View {
+  @State private var active = false
+
+  public let title: String
+  public let selection: Binding<SelectionValue>
+  public let options: [Option]
+
+  public var body: some View {
+    NavigationLink(
+      isActive: $active,
+      destination: {
+        List {
+          ForEach(options) { option in
+            Item(active: $active, selection: selection, option: option)
+          }
+        }
+        .navigationTitle(title)
+      },
+      label: {
+        Label(title: title, selection: selection, options: options)
+      }
+    )
+  }
+
+  public init(
+    _ title: String,
+    selection: Binding<SelectionValue>,
+    options: () -> [Option]
+  ) {
+    self.title = title
+    self.selection = selection
+    self.options = options()
+  }
+}
+
+struct NavigationPicker_Previews: PreviewProvider {
+  struct PreviewContainer: View {
+    @State private var selection = "First"
+
+    var body: some View {
+      NavigationView {
+        List {
+          NavigationPicker("Picker Title", selection: $selection) {
+            ["First", "Second"].map { value in
+              NavigationPicker.Option(id: value) {
+                Text(value)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  static var previews: some View {
+    PreviewContainer()
+  }
+}

--- a/RoutineJournalUI/NavigationPicker/NavigationPickerOptionPosition.swift
+++ b/RoutineJournalUI/NavigationPicker/NavigationPickerOptionPosition.swift
@@ -1,0 +1,4 @@
+public enum NavigationPickerOptionPosition {
+  case destination
+  case label
+}


### PR DESCRIPTION
- `Picker(...).pickerStyle(.navigationLink)` is available from iOS 16, but the application targets older versions too.
- `Picker` does not allow to determine in which position the selected option is viewed. This does not allow conditional styles.
