### PR TITLE
Add new extensions for `ProjectDescription` modules

### DIFF
--- a/RoutineJournal/Project.swift
+++ b/RoutineJournal/Project.swift
@@ -14,9 +14,7 @@ let project = Project(
       infoPlist: .extendingDefault(with: [
         "UILaunchScreen": [:]
       ]),
-      sources: .relative("**/*.swift", excluding: [
-        "Project.swift"
-      ]),
+      sources: .relative("**/*.swift"),
       scripts: [
         .make("lint-app")
       ],

--- a/RoutineJournal/Project.swift
+++ b/RoutineJournal/Project.swift
@@ -19,18 +19,8 @@ let project = Project(
         .make("lint-app")
       ],
       dependencies: [
-        .project(
-          target: "RoutineJournalCore",
-          path: .relativeToRoot("RoutineJournalCore")
-        ),
-        .project(
-          target: "RoutineJournalHome",
-          path: .relativeToRoot("RoutineJournalHome")
-        ),
-        .project(
-          target: "RoutineJournalUI",
-          path: .relativeToRoot("RoutineJournalUI")
-        )
+        .project("RoutineJournalHome"),
+        .project("RoutineJournalUI")
       ]
     )
   ]

--- a/RoutineJournal/Project.swift
+++ b/RoutineJournal/Project.swift
@@ -16,7 +16,7 @@ let project = Project(
       ]),
       sources: .relative("**/*.swift"),
       scripts: [
-        .make("lint-app")
+        .lint("RoutineJournal")
       ],
       dependencies: [
         .project("RoutineJournalHome"),

--- a/RoutineJournalCore/Project.swift
+++ b/RoutineJournalCore/Project.swift
@@ -17,8 +17,7 @@ let project = Project(
       bundleId: "my.vanyauhalin.RoutineJournalCore",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
       sources: .relative("**/*.swift", excluding: [
-        "**/*Tests.swift",
-        "Project.swift"
+        "**/*Tests.swift"
       ]),
       scripts: [
         .make("lint-core")

--- a/RoutineJournalCore/Project.swift
+++ b/RoutineJournalCore/Project.swift
@@ -20,7 +20,7 @@ let project = Project(
         "**/*Tests.swift"
       ]),
       scripts: [
-        .make("lint-core")
+        .lint("RoutineJournalCore")
       ],
       dependencies: [
         .package(product: "RealmSwift")

--- a/RoutineJournalEventForm/Project.swift
+++ b/RoutineJournalEventForm/Project.swift
@@ -10,9 +10,7 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalEventForm",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      sources: .relative("**/*.swift", excluding: [
-        "Project.swift"
-      ]),
+      sources: .relative("**/*.swift"),
       scripts: [
         .make("lint-event-form")
       ],

--- a/RoutineJournalEventForm/Project.swift
+++ b/RoutineJournalEventForm/Project.swift
@@ -10,9 +10,6 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalEventForm",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      infoPlist: .extendingDefault(with: [
-        "UILaunchScreen": [:]
-      ]),
       sources: .relative("**/*.swift", excluding: [
         "Project.swift"
       ]),

--- a/RoutineJournalEventForm/Project.swift
+++ b/RoutineJournalEventForm/Project.swift
@@ -15,18 +15,9 @@ let project = Project(
         .make("lint-event-form")
       ],
       dependencies: [
-        .project(
-          target: "RoutineJournalCore",
-          path: .relativeToRoot("RoutineJournalCore")
-        ),
-        .project(
-          target: "RoutineJournalIcon",
-          path: .relativeToRoot("RoutineJournalIcon")
-        ),
-        .project(
-          target: "RoutineJournalUI",
-          path: .relativeToRoot("RoutineJournalUI")
-        )
+        .project("RoutineJournalCore"),
+        .project("RoutineJournalIcon"),
+        .project("RoutineJournalUI")
       ]
     )
   ]

--- a/RoutineJournalEventForm/Project.swift
+++ b/RoutineJournalEventForm/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
       sources: .relative("**/*.swift"),
       scripts: [
-        .make("lint-event-form")
+        .lint("RoutineJournalEventForm")
       ],
       dependencies: [
         .project("RoutineJournalCore"),

--- a/RoutineJournalHome/Project.swift
+++ b/RoutineJournalHome/Project.swift
@@ -10,9 +10,7 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalHome",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      sources: .relative("**/*.swift", excluding: [
-        "Project.swift"
-      ]),
+      sources: .relative("**/*.swift"),
       scripts: [
         .make("lint-home")
       ],

--- a/RoutineJournalHome/Project.swift
+++ b/RoutineJournalHome/Project.swift
@@ -15,22 +15,10 @@ let project = Project(
         .make("lint-home")
       ],
       dependencies: [
-        .project(
-          target: "RoutineJournalCore",
-          path: .relativeToRoot("RoutineJournalCore")
-        ),
-        .project(
-          target: "RoutineJournalEventForm",
-          path: .relativeToRoot("RoutineJournalEventForm")
-        ),
-        .project(
-          target: "RoutineJournalTimeline",
-          path: .relativeToRoot("RoutineJournalTimeline")
-        ),
-        .project(
-          target: "RoutineJournalUI",
-          path: .relativeToRoot("RoutineJournalUI")
-        )
+        .project("RoutineJournalCore"),
+        .project("RoutineJournalEventForm"),
+        .project("RoutineJournalTimeline"),
+        .project("RoutineJournalUI")
       ]
     )
   ]

--- a/RoutineJournalHome/Project.swift
+++ b/RoutineJournalHome/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
       sources: .relative("**/*.swift"),
       scripts: [
-        .make("lint-home")
+        .lint("RoutineJournalHome")
       ],
       dependencies: [
         .project("RoutineJournalCore"),

--- a/RoutineJournalIcon/Project.swift
+++ b/RoutineJournalIcon/Project.swift
@@ -15,14 +15,8 @@ let project = Project(
         .make("lint-icon")
       ],
       dependencies: [
-        .project(
-          target: "RoutineJournalCore",
-          path: .relativeToRoot("RoutineJournalCore")
-        ),
-        .project(
-          target: "RoutineJournalUI",
-          path: .relativeToRoot("RoutineJournalUI")
-        )
+        .project("RoutineJournalCore"),
+        .project("RoutineJournalUI")
       ]
     )
   ]

--- a/RoutineJournalIcon/Project.swift
+++ b/RoutineJournalIcon/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
       sources: .relative("**/*.swift"),
       scripts: [
-        .make("lint-icon")
+        .lint("RoutineJournalIcon")
       ],
       dependencies: [
         .project("RoutineJournalCore"),

--- a/RoutineJournalIcon/Project.swift
+++ b/RoutineJournalIcon/Project.swift
@@ -10,9 +10,7 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalIcon",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      sources: .relative("**/*.swift", excluding: [
-        "Project.swift"
-      ]),
+      sources: .relative("**/*.swift"),
       scripts: [
         .make("lint-icon")
       ],

--- a/RoutineJournalTimeline/Project.swift
+++ b/RoutineJournalTimeline/Project.swift
@@ -10,9 +10,6 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalTimeline",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      infoPlist: .extendingDefault(with: [
-        "UILaunchScreen": [:]
-      ]),
       sources: .relative("**/*.swift", excluding: [
         "Project.swift"
       ]),

--- a/RoutineJournalTimeline/Project.swift
+++ b/RoutineJournalTimeline/Project.swift
@@ -10,9 +10,7 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalTimeline",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      sources: .relative("**/*.swift", excluding: [
-        "Project.swift"
-      ]),
+      sources: .relative("**/*.swift"),
       scripts: [
         .make("lint-timeline")
       ],

--- a/RoutineJournalTimeline/Project.swift
+++ b/RoutineJournalTimeline/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
       sources: .relative("**/*.swift"),
       scripts: [
-        .make("lint-timeline")
+        .lint("RoutineJournalTimeline")
       ],
       dependencies: [
         .project("RoutineJournalCore"),

--- a/RoutineJournalTimeline/Project.swift
+++ b/RoutineJournalTimeline/Project.swift
@@ -15,18 +15,9 @@ let project = Project(
         .make("lint-timeline")
       ],
       dependencies: [
-        .project(
-          target: "RoutineJournalCore",
-          path: .relativeToRoot("RoutineJournalCore")
-        ),
-        .project(
-          target: "RoutineJournalIcon",
-          path: .relativeToRoot("RoutineJournalIcon")
-        ),
-        .project(
-          target: "RoutineJournalUI",
-          path: .relativeToRoot("RoutineJournalUI")
-        )
+        .project("RoutineJournalCore"),
+        .project("RoutineJournalIcon"),
+        .project("RoutineJournalUI")
       ]
     )
   ]

--- a/RoutineJournalUI/Project.swift
+++ b/RoutineJournalUI/Project.swift
@@ -16,10 +16,7 @@ let project = Project(
       ],
       dependencies: [
         .target(name: "RoutineJournalUIResources"),
-        .project(
-          target: "RoutineJournalCore",
-          path: .relativeToRoot("RoutineJournalCore")
-        )
+        .project("RoutineJournalCore")
       ]
     ),
     Target(

--- a/RoutineJournalUI/Project.swift
+++ b/RoutineJournalUI/Project.swift
@@ -10,9 +10,6 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalUI",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      infoPlist: .extendingDefault(with: [
-        "UILaunchScreen": [:]
-      ]),
       sources: .relative("**/*.swift", excluding: [
         "Project.swift"
       ]),
@@ -33,9 +30,6 @@ let project = Project(
       product: .bundle,
       bundleId: "my.vanyauhalin.RoutineJournalUIResources",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      infoPlist: .extendingDefault(with: [
-        "UILaunchScreen": [:]
-      ]),
       resources: "Resources/**"
     )
   ]

--- a/RoutineJournalUI/Project.swift
+++ b/RoutineJournalUI/Project.swift
@@ -10,9 +10,7 @@ let project = Project(
       product: .framework,
       bundleId: "my.vanyauhalin.RoutineJournalUI",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      sources: .relative("**/*.swift", excluding: [
-        "Project.swift"
-      ]),
+      sources: .relative("**/*.swift"),
       scripts: [
         .make("lint-ui")
       ],

--- a/RoutineJournalUI/Project.swift
+++ b/RoutineJournalUI/Project.swift
@@ -12,7 +12,7 @@ let project = Project(
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
       sources: .relative("**/*.swift"),
       scripts: [
-        .make("lint-ui")
+        .lint("RoutineJournalUI")
       ],
       dependencies: [
         .target(name: "RoutineJournalUIResources"),

--- a/RoutineJournalUI/Project.swift
+++ b/RoutineJournalUI/Project.swift
@@ -28,7 +28,7 @@ let project = Project(
       product: .bundle,
       bundleId: "my.vanyauhalin.RoutineJournalUIResources",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
-      resources: "Resources/**"
+      resources: .relative("Resources/**")
     )
   ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -4,9 +4,15 @@ import ProjectDescription
 let root = FileManager.default.currentDirectoryPath
 
 extension SourceFilesList {
-  public static func relative(_ path: String, excluding: [Path] = []) -> Self {
+  public static func relative(
+    _ path: String,
+    excluding: [Path] = []
+  ) -> SourceFilesList {
     SourceFilesList(globs: [
-      .glob(.relativeToManifest(path), excluding: excluding)
+      .glob(
+        .relativeToManifest(path),
+        excluding: excluding + ["Project.swift"]
+      )
     ])
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -33,3 +33,9 @@ extension ProjectDescription.TargetScript {
     )
   }
 }
+
+extension ProjectDescription.TargetDependency {
+  public static func project(_ target: String) -> TargetDependency {
+    .project(target: target, path: .relativeToRoot(target))
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -17,6 +17,14 @@ extension SourceFilesList {
   }
 }
 
+extension ProjectDescription.ResourceFileElements {
+  public static func relative(_ path: String) -> ResourceFileElements {
+    ResourceFileElements(resources: [
+      ResourceFileElement.glob(pattern: .relativeToManifest(path))
+    ])
+  }
+}
+
 extension ProjectDescription.TargetScript {
   public static func make(_ command: String) -> Self {
     .pre(

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ProjectDescription
 
-let root = FileManager.default.currentDirectoryPath
+private let root = FileManager.default.currentDirectoryPath
 
 extension SourceFilesList {
   public static func relative(
@@ -26,11 +26,17 @@ extension ProjectDescription.ResourceFileElements {
 }
 
 extension ProjectDescription.TargetScript {
-  public static func make(_ command: String) -> Self {
+  private static let makefile = "\(root)/Makefile"
+
+  public static func make(_ subcommand: String) -> TargetScript {
     .pre(
-      script: "make -f \(root)/Makefile \(command)",
-      name: "make \(command)"
+      script: "make -f \(makefile) \(subcommand)",
+      name: "make \(subcommand)"
     )
+  }
+
+  public static func lint(_ project: String) -> TargetScript {
+    .make("lint project=\(project)")
   }
 }
 


### PR DESCRIPTION
- Delete unnecessary `infoPlist` extensions
- Add `Project.swift` as default exclusion path for source files
- Extend `ProjectDescription.ResourceFileElements` with the `relative` method
- Extend `ProjectDescription.TargetDependency` with the `project` method
- Make `lint` command generic
- Extend `ProjectDescription.TargetScript` with the `lint` method
