### PR TITLE
Delete unnecessary initialization methods and typealiases in `IconPicker` modules

### DIFF
--- a/RoutineJournalCategoryForm/CategoryFormAppearanceSection/View/CategoryFormAppearanceSection.swift
+++ b/RoutineJournalCategoryForm/CategoryFormAppearanceSection/View/CategoryFormAppearanceSection.swift
@@ -32,8 +32,7 @@ public struct CategoryFormAppearanceSection: SwiftUI.View {
       ColorThemePicker
         .render()
         .selection(model.selectionColorTheme)
-      IconPicker
-        .render()
+      IconPicker()
         .selection(model.selectionIcon)
         .colorTheme(model.colorTheme)
     }

--- a/RoutineJournalIconPicker/IconPicker/Model/IconPickerModel.swift
+++ b/RoutineJournalIconPicker/IconPicker/Model/IconPickerModel.swift
@@ -27,24 +27,6 @@ public final class IconPickerModel:
     self.colorTheme = .default
   }
 
-  public init(
-    iconSelection: Binding<IconObject> = .constant(.default),
-    colorTheme: ColorTheme = .default
-  ) {
-    self.iconSelection = iconSelection
-    self.colorTheme = colorTheme
-  }
-
-  public func reinit(
-    iconSelection: Binding<IconObject>? = nil,
-    colorTheme: ColorTheme? = nil
-  ) -> Model {
-    Model(
-      iconSelection: iconSelection ?? self.iconSelection,
-      colorTheme: colorTheme ?? self.colorTheme
-    )
-  }
-
   public func showExplorer() {
     showingExplorer = true
   }

--- a/RoutineJournalIconPicker/IconPicker/Model/IconPickerModel.swift
+++ b/RoutineJournalIconPicker/IconPicker/Model/IconPickerModel.swift
@@ -8,8 +8,6 @@ public final class IconPickerModel:
   MVIIconSelectionModifierModel,
   MVIColorThemeModifierModel
 {
-  public typealias Model = IconPickerModel
-
   public static let title = "Icon"
 
   @Published

--- a/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
+++ b/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
@@ -5,20 +5,15 @@ import RoutineJournalIconView
 import RoutineJournalUI
 import SwiftUI
 
-public struct IconPicker:
-  SwiftUI.View,
-  MVIIconSelectionModifier,
-  MVIColorThemeModifier
-{
+public struct IconPicker: MVIIconSelectionModifier, MVIColorThemeModifier {
   public typealias Intent = IconPickerIntent
   public typealias Model = IconPickerModel
-  public typealias View = IconPicker
 
   @ObservedObject
   public var model: Model
   public var intent: Intent
 
-  public var body: some SwiftUI.View {
+  public var body: some View {
     NavigationButton(
       Model.title,
       action: {

--- a/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
+++ b/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
@@ -44,12 +44,6 @@ public struct IconPicker:
     self.model = model
     self.intent = intent
   }
-
-  public static func render() -> View {
-    let model = Model()
-    let intent = Intent(model: model)
-    return View(model: model, intent: intent)
-  }
 }
 
 struct IconPickerView_Previews: PreviewProvider {
@@ -61,8 +55,7 @@ struct IconPickerView_Previews: PreviewProvider {
       PreviewBinding($icon) {
         NavigationView {
           Form {
-            IconPicker
-              .render()
+            IconPicker()
               .selection($icon)
               .colorTheme(.indigo)
           }

--- a/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
+++ b/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
@@ -32,8 +32,7 @@ public struct IconPicker:
       }
     )
     .sheet(isPresented: $model.showingExplorer) {
-      IconPickerExplorer
-        .render()
+      IconPickerExplorer()
         .selection(model.iconSelection)
         .colorTheme(model.colorTheme)
     }

--- a/RoutineJournalIconPicker/IconPickerExplorer/Model/IconPickerExplorerModel.swift
+++ b/RoutineJournalIconPicker/IconPickerExplorer/Model/IconPickerExplorerModel.swift
@@ -22,22 +22,4 @@ public final class IconPickerExplorerModel:
     self.iconSelection = .constant(.default)
     self.colorTheme = .default
   }
-
-  public init(
-    iconSelection: Binding<IconObject> = .constant(.default),
-    colorTheme: ColorTheme = .default
-  ) {
-    self.iconSelection = iconSelection
-    self.colorTheme = colorTheme
-  }
-
-  public func reinit(
-    iconSelection: Binding<IconObject>? = nil,
-    colorTheme: ColorTheme? = nil
-  ) -> Model {
-    Model(
-      iconSelection: iconSelection ?? self.iconSelection,
-      colorTheme: colorTheme ?? self.colorTheme
-    )
-  }
 }

--- a/RoutineJournalIconPicker/IconPickerExplorer/Model/IconPickerExplorerModel.swift
+++ b/RoutineJournalIconPicker/IconPickerExplorer/Model/IconPickerExplorerModel.swift
@@ -8,8 +8,6 @@ public final class IconPickerExplorerModel:
   MVIconSelectionModifierModel,
   MVColorThemeModifierModel
 {
-  public typealias Model = IconPickerExplorerModel
-
   public static let title = IconPickerModel.title
 
   @Published

--- a/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
+++ b/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
@@ -46,15 +46,6 @@ public struct IconPickerExplorer:
   public init() {
     self.model = Model()
   }
-
-  public init(model: Model) {
-    self.model = model
-  }
-
-  public static func render() -> View {
-    let model = Model()
-    return View(model: model)
-  }
 }
 
 struct IconPickerExplorer_Previews: PreviewProvider {
@@ -65,8 +56,7 @@ struct IconPickerExplorer_Previews: PreviewProvider {
     var body: some View {
       PreviewBinding($icon) {
         PreviewSheet { _ in
-          IconPickerExplorer
-            .render()
+          IconPickerExplorer()
             .selection($icon)
             .colorTheme(.indigo)
         }

--- a/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
+++ b/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
@@ -20,8 +20,7 @@ public struct IconPickerExplorer:
 
   public var body: some SwiftUI.View {
     NavigationView {
-      IconPickerOptions
-        .render()
+      IconPickerOptions()
         .selection(model.iconSelection)
         .colorTheme(model.colorTheme)
         .query($model.query)

--- a/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
+++ b/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
@@ -5,12 +5,10 @@ import RoutineJournalUI
 import SwiftUI
 
 public struct IconPickerExplorer:
-  SwiftUI.View,
   MVIconSelectionModifier,
   MVColorThemeModifier
 {
   public typealias Model = IconPickerExplorerModel
-  public typealias View = IconPickerExplorer
 
   @Environment(\.dismiss)
   private var dismiss
@@ -18,7 +16,7 @@ public struct IconPickerExplorer:
   @ObservedObject
   public var model: Model
 
-  public var body: some SwiftUI.View {
+  public var body: some View {
     NavigationView {
       IconPickerOptions()
         .selection(model.iconSelection)

--- a/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
@@ -9,7 +9,6 @@ public final class IconPickerOptionIntent:
   MVIColorThemeModifierIntent,
   MVISelectModifierIntent
 {
-  public typealias Intent = IconPickerOptionIntent
   public typealias Model = IconPickerOptionModel
 
   public weak var model: Model?
@@ -18,24 +17,6 @@ public final class IconPickerOptionIntent:
 
   public init() {
     self.selectAction = {}
-  }
-
-  public init(
-    model: Model,
-    selectAction: @escaping () -> Void = {}
-  ) {
-    self.model = model
-    self.selectAction = selectAction
-  }
-
-  public func reinit(
-    model: Model,
-    selectAction: (() -> Void)? = nil
-  ) -> Intent {
-    Intent(
-      model: model,
-      selectAction: selectAction ?? self.selectAction
-    )
   }
 
   public func onSelect() {

--- a/RoutineJournalIconPicker/IconPickerOption/Model/IconPickerOptionModel.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/Model/IconPickerOptionModel.swift
@@ -38,28 +38,6 @@ public final class IconPickerOptionModel:
     self.colorTheme = .default
   }
 
-  public init(
-    icon: IconObject = .default,
-    iconSelection: Binding<IconObject> = .constant(.default),
-    colorTheme: ColorTheme = .default
-  ) {
-    self.icon = icon
-    self.iconSelection = iconSelection
-    self.colorTheme = colorTheme
-  }
-
-  public func reinit(
-    icon: IconObject? = nil,
-    iconSelection: Binding<IconObject>? = nil,
-    colorTheme: ColorTheme? = nil
-  ) -> Model {
-    Model(
-      icon: icon ?? self.icon,
-      iconSelection: iconSelection ?? self.iconSelection,
-      colorTheme: colorTheme ?? self.colorTheme
-    )
-  }
-
   public func select() {
     iconSelection.wrappedValue = icon
   }

--- a/RoutineJournalIconPicker/IconPickerOption/Model/IconPickerOptionModel.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/Model/IconPickerOptionModel.swift
@@ -12,8 +12,6 @@ public final class IconPickerOptionModel:
   MVIColorThemeModifierModel,
   MVISelectModifierModel
 {
-  public typealias Model = IconPickerOptionModel
-
   public static let cornerRadius: Double = 7
   public static let width: Double = 28 + 8
   public static let height: Double = 28 + 8

--- a/RoutineJournalIconPicker/IconPickerOption/View/IconPickerOption.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/View/IconPickerOption.swift
@@ -8,7 +8,6 @@ import RoutineJournalUI
 import SwiftUI
 
 public struct IconPickerOption:
-  SwiftUI.View,
   MVIIconModifier,
   MVIIconSelectionModifier,
   MVIColorThemeModifier,
@@ -16,12 +15,11 @@ public struct IconPickerOption:
 {
   public typealias Intent = IconPickerOptionIntent
   public typealias Model = IconPickerOptionModel
-  public typealias View = IconPickerOption
 
   public var model: Model
   public var intent: Intent
 
-  public var body: some SwiftUI.View {
+  public var body: some View {
     Button(
       action: {
         intent.onSelect()

--- a/RoutineJournalIconPicker/IconPickerOption/View/IconPickerOption.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/View/IconPickerOption.swift
@@ -50,17 +50,6 @@ public struct IconPickerOption:
     self.model = model
     self.intent = intent
   }
-
-  public init(model: Model, intent: Intent) {
-    self.model = model
-    self.intent = intent
-  }
-
-  public static func render() -> View {
-    let model = Model()
-    let intent = Intent(model: model)
-    return View(model: model, intent: intent)
-  }
 }
 
 struct IconPickerOption_Previews: PreviewProvider {
@@ -74,16 +63,14 @@ struct IconPickerOption_Previews: PreviewProvider {
     var body: some View {
       PreviewBinding($icon) {
         PreviewSheet { toggle in
-          IconPickerOption
-            .render()
+          IconPickerOption()
             .icon(first)
             .selection($icon)
             .colorTheme(.default)
             .onSelect {
               toggle()
             }
-          IconPickerOption
-            .render()
+          IconPickerOption()
             .icon(last)
             .selection($icon)
             .colorTheme(.indigo)

--- a/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
@@ -9,7 +9,6 @@ public final class IconPickerOptionsIntent:
   MVIQueryModifierIntent,
   MVISelectModifierIntent
 {
-  public typealias Intent = IconPickerOptionsIntent
   public typealias Model = IconPickerOptionsModel
 
   public weak var model: Model?
@@ -18,14 +17,6 @@ public final class IconPickerOptionsIntent:
 
   public init() {
     self.selectAction = {}
-  }
-
-  public init(selectAction: @escaping () -> Void = {}) {
-    self.selectAction = selectAction
-  }
-
-  public func reinit(selectAction: (() -> Void)? = nil) -> Intent {
-    Intent(selectAction: selectAction ?? self.selectAction)
   }
 
   public func onSelect() {

--- a/RoutineJournalIconPicker/IconPickerOptions/Model/IconPickerOptionsModel.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/Model/IconPickerOptionsModel.swift
@@ -52,18 +52,6 @@ public final class IconPickerOptionsModel:
     self.subscribe()
   }
 
-  public init(
-    iconSelection: Binding<IconObject> = .constant(.default),
-    colorTheme: ColorTheme = .default,
-    query: Binding<String> = .constant(.default)
-  ) {
-    self.icons = IconObject.objects()
-    self.iconSelection = iconSelection
-    self.colorTheme = colorTheme
-    self.query = query
-    self.subscribe()
-  }
-
   private func subscribe() {
     icons?
       .objectWillChange
@@ -71,17 +59,5 @@ public final class IconPickerOptionsModel:
         self?.objectWillChange.send()
       }
       .store(in: &subscriptions)
-  }
-
-  public func reinit(
-    iconSelection: Binding<IconObject>? = nil,
-    colorTheme: ColorTheme? = nil,
-    query: Binding<String>? = nil
-  ) -> Model {
-    Model(
-      iconSelection: iconSelection ?? self.iconSelection,
-      colorTheme: colorTheme ?? self.colorTheme,
-      query: query ?? self.query
-    )
   }
 }

--- a/RoutineJournalIconPicker/IconPickerOptions/Model/IconPickerOptionsModel.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/Model/IconPickerOptionsModel.swift
@@ -14,8 +14,6 @@ public final class IconPickerOptionsModel:
   MVIQueryModifierModel,
   MVISelectModifierModel
 {
-  public typealias Model = IconPickerOptionsModel
-
   public static let width: Double = 28
   public static let spacing: Double = 8
 

--- a/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
@@ -61,17 +61,6 @@ public struct IconPickerOptions:
     self.model = model
     self.intent = intent
   }
-
-  public init(model: Model, intent: Intent) {
-    self.model = model
-    self.intent = intent
-  }
-
-  public static func render() -> View {
-    let model = Model()
-    let intent = Intent()
-    return View(model: model, intent: intent)
-  }
 }
 
 struct IconPickerOptions_Previews: PreviewProvider {
@@ -85,8 +74,7 @@ struct IconPickerOptions_Previews: PreviewProvider {
       PreviewBinding($icon) {
         PreviewBinding($query, position: (.bottom, .trailing)) {
           PreviewSheet { toggle in
-            IconPickerOptions
-              .render()
+            IconPickerOptions()
               .selection($icon)
               .colorTheme(.indigo)
               .query($query)

--- a/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
@@ -40,8 +40,7 @@ public struct IconPickerOptions:
         Section(title) {
           LazyVGrid(columns: columns, spacing: spacing) {
             ForEach(icons) { icon in
-              IconPickerOption
-                .render()
+              IconPickerOption()
                 .icon(icon)
                 .selection(model.iconSelection)
                 .colorTheme(model.colorTheme)

--- a/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
@@ -7,7 +7,6 @@ import RoutineJournalUI
 import SwiftUI
 
 public struct IconPickerOptions:
-  SwiftUI.View,
   MVIIconSelectionModifier,
   MVIColorThemeModifier,
   MVIQueryModifier,
@@ -15,7 +14,6 @@ public struct IconPickerOptions:
 {
   public typealias Intent = IconPickerOptionsIntent
   public typealias Model = IconPickerOptionsModel
-  public typealias View = IconPickerOptions
 
   @ScaledMetric
   private var scale = 1
@@ -34,7 +32,7 @@ public struct IconPickerOptions:
     [GridItem(.adaptive(minimum: width), spacing: spacing)]
   }
 
-  public var body: some SwiftUI.View {
+  public var body: some View {
     List {
       ForEach(model.collections, id: \.self.0) { title, icons in
         Section(title) {


### PR DESCRIPTION
- Delete unnecessary `IconPickerOption` initialization methods
- Delete unnecessary `IconPickerOptions` initialization methods
- Delete unnecessary `IconPickerExplorer` initialization methods
- Delete unnecessary `IconPickerOptionModule` initialization methods
- Delete unnecessary `IconPickerOptionIntent` initialization methods
- Delete unnecessary `IconPickerOptionsModel` initialization methods
- Delete unnecessary `IconPickerOptionsIntent` initialization methods
- Delete unnecessary typealiases in `IconPickerOption`
- Delete unnecessary typealiases in `IconPickerOptions`
- Delete unnecessary `IconPickerExplorerModel` initialization methods
- Delete unnecessary typealiases in `IconPickerExplorer`
- Delete unnecessary `IconPicker` initialization methods
- Delete unnecessary typealiases in `IconPicker`
