### PR TITLE
Extend objects with `mock` properties to use them in previews

### DIFF
--- a/RoutineJournalCore/Objects/CategoryObject/CategoryObject+mock.swift
+++ b/RoutineJournalCore/Objects/CategoryObject/CategoryObject+mock.swift
@@ -1,0 +1,13 @@
+#if DEBUG
+extension CategoryObject {
+  public static var mock1: CategoryObject {
+    CategoryObject(title: "Flights", icon: .mock1, colorTheme: .indigo)
+  }
+  public static var mock2: CategoryObject {
+    CategoryObject(title: "Shopping Trip", icon: .mock2, colorTheme: .rose)
+  }
+  public static var mock3: CategoryObject {
+    CategoryObject(title: "Unknown Category", icon: .mock3, colorTheme: .blue)
+  }
+}
+#endif

--- a/RoutineJournalCore/Objects/EventObject/EventObject+mock.swift
+++ b/RoutineJournalCore/Objects/EventObject/EventObject+mock.swift
@@ -1,0 +1,41 @@
+#if DEBUG
+import Foundation
+
+extension EventObject {
+  public static var mock1: EventObject {
+    EventObject(
+      category: .mock1,
+      title: "Flight from London to Paris",
+      notes: "Almost missed my flight",
+      startDate: minutes(),
+      endDate: minutes(80)
+    )
+  }
+  public static var mock2: EventObject {
+    EventObject(
+      category: .mock2,
+      title: "Shopping in an airport boutique",
+      notes: "Finally I have this perfume",
+      startDate: minutes(80 + 5),
+      endDate: minutes(80 + 5 + 130)
+    )
+  }
+  public static var mock3: EventObject {
+    EventObject(
+      category: .mock3,
+      title: "Unknown event",
+      notes: "Something unknown happened",
+      startDate: minutes(80 + 5 + 130 + 20),
+      endDate: minutes(80 + 5 + 130 + 20 + 10)
+    )
+  }
+
+  private static func minutes(_ minutes: Int = .zero) -> Date {
+    let now = Date.now
+    return Calendar
+      .current
+      .date(byAdding: .minute, value: minutes, to: now)
+      ?? now
+  }
+}
+#endif

--- a/RoutineJournalCore/Objects/IconObject/IconObject+mock.swift
+++ b/RoutineJournalCore/Objects/IconObject/IconObject+mock.swift
@@ -1,0 +1,13 @@
+#if DEBUG
+extension IconObject {
+  public static var mock1: IconObject {
+    IconObject(name: .airplane, type: .system)
+  }
+  public static var mock2: IconObject {
+    IconObject(name: .cart, type: .system)
+  }
+  public static var mock3: IconObject {
+    IconObject(name: .questionmark, type: .system)
+  }
+}
+#endif


### PR DESCRIPTION
- Extend `IconObject` with `mock` properties to use them in previews
- Extend `CategoryObject` with `mock` properties to use them in previews
- Extend `EventObject` with `mock` properties to use them in previews
