### PR TITLE
Clean and apply modifiers to `CategoryForm` modules

### DIFF
--- a/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
@@ -7,10 +7,6 @@ public final class CategoryFormIntent: MVIIntent {
 
   public init() {}
 
-  public init(model: Model) {
-    self.model = model
-  }
-
   public func onCancel() {}
 
   public func onConfirm() {}

--- a/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
@@ -1,7 +1,11 @@
-public final class CategoryFormIntent {
+import RoutineJournalMVI
+
+public final class CategoryFormIntent: MVIIntent {
   public typealias Model = CategoryFormModel
 
-  private weak var model: Model?
+  public weak var model: Model?
+
+  public init() {}
 
   public init(model: Model) {
     self.model = model

--- a/RoutineJournalCategoryForm/CategoryForm/Model/CategoryFormModel.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Model/CategoryFormModel.swift
@@ -12,13 +12,9 @@ public final class CategoryFormModel: ObservableObject {
   @Published
   public var colorTheme: ColorTheme
 
-  public init(
-    name: String = .default,
-    icon: IconObject = .default,
-    colorTheme: ColorTheme = .default
-  ) {
-    self.name = name
-    self.icon = icon
-    self.colorTheme = colorTheme
+  public init() {
+    self.name = .default
+    self.icon = .default
+    self.colorTheme = .default
   }
 }

--- a/RoutineJournalCategoryForm/CategoryForm/Model/CategoryFormModel.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Model/CategoryFormModel.swift
@@ -3,7 +3,7 @@ import RoutineJournalCore
 import RoutineJournalFoundation
 
 public final class CategoryFormModel: ObservableObject {
-  public let navigationTitle = "New Category"
+  public static let title = "New Category"
 
   @Published public var name: String
   @Published public var icon: IconObject

--- a/RoutineJournalCategoryForm/CategoryForm/Model/CategoryFormModel.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Model/CategoryFormModel.swift
@@ -5,9 +5,12 @@ import RoutineJournalFoundation
 public final class CategoryFormModel: ObservableObject {
   public static let title = "New Category"
 
-  @Published public var name: String
-  @Published public var icon: IconObject
-  @Published public var colorTheme: ColorTheme
+  @Published
+  public var name: String
+  @Published
+  public var icon: IconObject
+  @Published
+  public var colorTheme: ColorTheme
 
   public init(
     name: String = .default,

--- a/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
@@ -1,18 +1,20 @@
 import RoutineJournalAppearanceSection
+import RoutineJournalMVI
 import RoutineJournalNameField
 import RoutineJournalUI
 import SwiftUI
 
-public struct CategoryForm: SwiftUI.View {
+public struct CategoryForm: MVIView {
   public typealias Intent = CategoryFormIntent
   public typealias Model = CategoryFormModel
   public typealias View = CategoryForm
 
   @Environment(\.dismiss)
   private var dismiss
+
   @ObservedObject
-  private var model: Model
-  private let intent: Intent
+  public var model: Model
+  public var intent: Intent
 
   public var body: some SwiftUI.View {
     NavigationView {
@@ -40,6 +42,13 @@ public struct CategoryForm: SwiftUI.View {
         }
       }
     }
+  }
+
+  public init() {
+    let model = Model()
+    let intent = Intent(model: model)
+    self.model = model
+    self.intent = intent
   }
 
   public init(model: Model, intent: Intent) {

--- a/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
@@ -21,7 +21,7 @@ public struct CategoryForm: SwiftUI.View {
           .selection($model.colorTheme)
           .selection($model.icon)
       }
-      .navigationTitle(model.navigationTitle)
+      .navigationTitle(Model.title)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {

--- a/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
@@ -8,8 +8,10 @@ public struct CategoryForm: SwiftUI.View {
   public typealias Model = CategoryFormModel
   public typealias View = CategoryForm
 
-  @Environment(\.dismiss) private var dismiss
-  @ObservedObject private var model: Model
+  @Environment(\.dismiss)
+  private var dismiss
+  @ObservedObject
+  private var model: Model
   private let intent: Intent
 
   public var body: some SwiftUI.View {

--- a/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
@@ -50,24 +50,12 @@ public struct CategoryForm: MVIView {
     self.model = model
     self.intent = intent
   }
-
-  public init(model: Model, intent: Intent) {
-    self.model = model
-    self.intent = intent
-  }
-
-  public static func render() -> View {
-    let model = Model()
-    let intent = Intent(model: model)
-    return View(model: model, intent: intent)
-  }
 }
 
 struct CategoryForm_Previews: PreviewProvider {
   static var previews: some View {
     PreviewContext { _ in
-      CategoryForm
-        .render()
+      CategoryForm()
     }
     .id(name)
     .data()

--- a/RoutineJournalCategoryForm/Project.swift
+++ b/RoutineJournalCategoryForm/Project.swift
@@ -18,6 +18,7 @@ let project = Project(
         .project("RoutineJournalAppearanceSection"),
         .project("RoutineJournalCore"),
         .project("RoutineJournalFoundation"),
+        .project("RoutineJournalMVI"),
         .project("RoutineJournalNameField"),
         .project("RoutineJournalUI")
       ]


### PR DESCRIPTION
- Make `CategoryForm` `title` property static
- Insert a new line after wrappers in `CategoryForm`
- Add `MVI` as a dependency for `CategoryForm`
- Apply `MVI` to `CategoryForm`
- Delete unnecessary `CategoryForm` initialization methods
