### PR TITLE
Make action property in action modifiers optional

### DIFF
--- a/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
@@ -6,9 +6,7 @@ public final class CategoryFormIntent: OnCancelModifier, OnConfirmModifier {
 
   public weak var model: Model?
   public var actionOnCancel: (() -> Void)?
-  public var actionOnConfirm: () -> Void
+  public var actionOnConfirm: (() -> Void)?
 
-  public init() {
-    self.actionOnConfirm = {}
-  }
+  public init() {}
 }

--- a/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Intent/CategoryFormIntent.swift
@@ -5,11 +5,10 @@ public final class CategoryFormIntent: OnCancelModifier, OnConfirmModifier {
   public typealias Model = CategoryFormModel
 
   public weak var model: Model?
-  public var actionOnCancel: () -> Void
+  public var actionOnCancel: (() -> Void)?
   public var actionOnConfirm: () -> Void
 
   public init() {
-    self.actionOnCancel = {}
     self.actionOnConfirm = {}
   }
 }

--- a/RoutineJournalCategoryPicker/CategoryPickerOption/Intent/CategoryPickerOptionIntent.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOption/Intent/CategoryPickerOptionIntent.swift
@@ -4,14 +4,12 @@ public final class CategoryPickerOptionIntent: OnSelectModifier {
   public typealias Model = CategoryPickerOptionModel
 
   public weak var model: Model?
-  public var actionOnSelect: () -> Void
+  public var actionOnSelect: (() -> Void)?
 
-  public init() {
-    self.actionOnSelect = {}
-  }
+  public init() {}
 
   public func onSelect() {
     model?.select()
-    actionOnSelect()
+    actionOnSelect?()
   }
 }

--- a/RoutineJournalCategoryPicker/CategoryPickerOptions/Intent/CategoryPickerOptionsIntent.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOptions/Intent/CategoryPickerOptionsIntent.swift
@@ -4,9 +4,7 @@ public final class CategoryPickerOptionsIntent: OnSelectModifier {
   public typealias Model = CategoryPickerOptionsModel
 
   public weak var model: Model?
-  public var actionOnSelect: () -> Void
+  public var actionOnSelect: (() -> Void)?
 
-  public init() {
-    self.actionOnSelect = {}
-  }
+  public init() {}
 }

--- a/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
@@ -4,14 +4,12 @@ public final class IconPickerOptionIntent: OnSelectModifier {
   public typealias Model = IconPickerOptionModel
 
   public weak var model: Model?
-  public var actionOnSelect: () -> Void
+  public var actionOnSelect: (() -> Void)?
 
-  public init() {
-    self.actionOnSelect = {}
-  }
+  public init() {}
 
   public func onSelect() {
     model?.select()
-    actionOnSelect()
+    actionOnSelect?()
   }
 }

--- a/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
@@ -4,9 +4,7 @@ public final class IconPickerOptionsIntent: OnSelectModifier {
   public typealias Model = IconPickerOptionsModel
 
   public weak var model: Model?
-  public var actionOnSelect: () -> Void
+  public var actionOnSelect: (() -> Void)?
 
-  public init() {
-    self.actionOnSelect = {}
-  }
+  public init() {}
 }

--- a/RoutineJournalOnCancelModifier/OnCancelModifier/Intent/OnCancelModifier.swift
+++ b/RoutineJournalOnCancelModifier/OnCancelModifier/Intent/OnCancelModifier.swift
@@ -1,7 +1,7 @@
 import RoutineJournalMVI
 
 public protocol OnCancelModifier: MVIIntent {
-  var actionOnCancel: () -> Void { get set }
+  var actionOnCancel: (() -> Void)? { get set }
 
   func reinit(model: Model, actionOnCancel: @escaping () -> Void) -> Self
 
@@ -19,6 +19,6 @@ extension OnCancelModifier {
   }
 
   public func onCancel() {
-    actionOnCancel()
+    actionOnCancel?()
   }
 }

--- a/RoutineJournalOnConfirmModifier/OnConfirmModifier/Intent/OnConfirmModifier.swift
+++ b/RoutineJournalOnConfirmModifier/OnConfirmModifier/Intent/OnConfirmModifier.swift
@@ -1,7 +1,7 @@
 import RoutineJournalMVI
 
 public protocol OnConfirmModifier: MVIIntent {
-  var actionOnConfirm: () -> Void { get set }
+  var actionOnConfirm: (() -> Void)? { get set }
 
   func reinit(model: Model, actionOnConfirm: @escaping () -> Void) -> Self
 
@@ -19,6 +19,6 @@ extension OnConfirmModifier {
   }
 
   public func onConfirm() {
-    actionOnConfirm()
+    actionOnConfirm?()
   }
 }

--- a/RoutineJournalOnSelectModifier/OnSelectModifier/Intent/OnSelectModifier.swift
+++ b/RoutineJournalOnSelectModifier/OnSelectModifier/Intent/OnSelectModifier.swift
@@ -1,7 +1,7 @@
 import RoutineJournalMVI
 
 public protocol OnSelectModifier: MVIIntent {
-  var actionOnSelect: () -> Void { get set }
+  var actionOnSelect: (() -> Void)? { get set }
 
   func reinit(model: Model, actionOnSelect: @escaping () -> Void) -> Self
 
@@ -19,6 +19,6 @@ extension OnSelectModifier {
   }
 
   public func onSelect() {
-    actionOnSelect()
+    actionOnSelect?()
   }
 }


### PR DESCRIPTION
- Make `OnCancelModifier` `actionOnCancel` optional
- Make `OnConfirmModifier` `actionOnConfirm` optional
- Make `OnSelectModifier` `actionOnSelect` optional
- Make `CategoryForm` `actionOnCancel` optional
- Make `CategoryForm` `actionOnCancel` optional
- Make `actionOnSelect` in `CategoryPicker` modules optional
- Make `actionOnSelect` in `IconPicker` modules optional
