### PR TITLE
Simplify `PreviewContext` `modifiers` and `values`

### DIFF
--- a/RoutineJournal/RoutineJournal.swift
+++ b/RoutineJournal/RoutineJournal.swift
@@ -9,7 +9,7 @@ struct RoutineJournal: App {
       PreviewContext { _ in
         HomeView()
       }
-      .data()
+      .modifier(.data)
     }
   }
 

--- a/RoutineJournalAppearanceSection/AppearanceSection/View/AppearanceSection.swift
+++ b/RoutineJournalAppearanceSection/AppearanceSection/View/AppearanceSection.swift
@@ -60,7 +60,7 @@ struct AppearanceSection_Previews: PreviewProvider {
         }
       }
       .id(AppearanceSection_Previews.name)
-      .data()
+      .modifier(.data)
     }
   }
 

--- a/RoutineJournalCategoryForm/CategoryForm/Style/ListItemCategoryFormStyle/View/ListItemCategoryFormStyle.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/Style/ListItemCategoryFormStyle/View/ListItemCategoryFormStyle.swift
@@ -52,6 +52,6 @@ struct ListItemCategoryFormStyle_Previews: PreviewProvider {
       }
     }
     .id(name)
-    .data()
+    .modifier(.data)
   }
 }

--- a/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
+++ b/RoutineJournalCategoryForm/CategoryForm/View/CategoryForm.swift
@@ -58,6 +58,6 @@ struct CategoryForm_Previews: PreviewProvider {
       CategoryForm()
     }
     .id(name)
-    .data()
+    .modifier(.data)
   }
 }

--- a/RoutineJournalCategoryPicker/CategoryPicker/View/CategoryPicker.swift
+++ b/RoutineJournalCategoryPicker/CategoryPicker/View/CategoryPicker.swift
@@ -54,7 +54,7 @@ struct CategoryPicker_Previews: PreviewProvider {
         }
       }
       .id(CategoryPicker_Previews.name)
-      .data()
+      .modifier(.data)
       .value(category?.title)
     }
   }

--- a/RoutineJournalCategoryPicker/CategoryPickerExplorer/View/CategoryPickerExplorer.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerExplorer/View/CategoryPickerExplorer.swift
@@ -52,8 +52,7 @@ struct CategoryPickerExplorer_Previews: PreviewProvider {
           .selection($category)
       }
       .id(CategoryPickerExplorer_Previews.name)
-      .data()
-      .sheet()
+      .modifier([.data, .sheet])
       .value(category?.title)
     }
   }

--- a/RoutineJournalCategoryPicker/CategoryPickerOption/View/CategoryPickerOption.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOption/View/CategoryPickerOption.swift
@@ -66,7 +66,7 @@ struct CategoryPickerOption_Previews: PreviewProvider {
         }
       }
       .id(CategoryPickerOption_Previews.name)
-      .sheet()
+      .modifier(.sheet)
       .value(category?.title)
     }
 

--- a/RoutineJournalCategoryPicker/CategoryPickerOptions/View/CategoryPickerOptions.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOptions/View/CategoryPickerOptions.swift
@@ -54,10 +54,8 @@ struct CategoryPickerOptions_Previews: PreviewProvider {
           }
       }
       .id(CategoryPickerOptions_Previews.name)
-      .data()
-      .sheet()
-      .value(category?.title)
-      .value(query)
+      .modifier([.data, .sheet])
+      .value([category?.title, query])
     }
   }
 

--- a/RoutineJournalEventForm/EventForm/View/EventForm.swift
+++ b/RoutineJournalEventForm/EventForm/View/EventForm.swift
@@ -76,7 +76,6 @@ struct EventForm_Previews: PreviewProvider {
         }
     }
     .id(name)
-    .data()
-    .sheet()
+    .modifier([.data, .sheet])
   }
 }

--- a/RoutineJournalEventForm/EventFormCategory/View/EventFormCategoryField.swift
+++ b/RoutineJournalEventForm/EventFormCategory/View/EventFormCategoryField.swift
@@ -69,7 +69,7 @@ struct EventFormCategoryField_Previews: PreviewProvider {
         }
       }
       .id(EventFormCategoryField_Previews.name)
-      .data()
+      .modifier(.data)
       .value(object?.title)
     }
   }

--- a/RoutineJournalEventForm/EventFormCategorySearch/View/EventFormCategorySearchView.swift
+++ b/RoutineJournalEventForm/EventFormCategorySearch/View/EventFormCategorySearchView.swift
@@ -73,7 +73,6 @@ struct EventFormCategorySearchView_Previews: PreviewProvider {
         .render(Binding.constant(nil))
     }
     .id(name)
-    .data()
-    .sheet()
+    .modifier([.data, .sheet])
   }
 }

--- a/RoutineJournalEventForm/EventFormCategorySearchResults/View/EventFormCategorySearchResultsView.swift
+++ b/RoutineJournalEventForm/EventFormCategorySearchResults/View/EventFormCategorySearchResultsView.swift
@@ -75,7 +75,6 @@ struct EventFormCategorySearchResultsView_Previews: PreviewProvider {
       .listStyle(.plain)
     }
     .id(name)
-    .data()
-    .sheet()
+    .modifier([.data, .sheet])
   }
 }

--- a/RoutineJournalHomeView/HomeTimelineView/View/HomeTimelineView.swift
+++ b/RoutineJournalHomeView/HomeTimelineView/View/HomeTimelineView.swift
@@ -39,6 +39,6 @@ struct HomeTimelineView_Previews: PreviewProvider {
         .render()
     }
     .id(name)
-    .data()
+    .modifier(.data)
   }
 }

--- a/RoutineJournalHomeView/HomeView/View/HomeView.swift
+++ b/RoutineJournalHomeView/HomeView/View/HomeView.swift
@@ -37,6 +37,6 @@ struct HomeView_Previews: PreviewProvider {
       HomeView()
     }
     .id(name)
-    .data()
+    .modifier(.data)
   }
 }

--- a/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
+++ b/RoutineJournalIconPicker/IconPicker/View/IconPicker.swift
@@ -55,7 +55,7 @@ struct IconPickerView_Previews: PreviewProvider {
         }
       }
       .id(IconPickerView_Previews.name)
-      .data()
+      .modifier(.data)
       .value(icon.name.rawValue)
     }
   }

--- a/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
+++ b/RoutineJournalIconPicker/IconPickerExplorer/View/IconPickerExplorer.swift
@@ -54,8 +54,7 @@ struct IconPickerExplorer_Previews: PreviewProvider {
           .colorTheme(.indigo)
       }
       .id(IconPickerExplorer_Previews.name)
-      .data()
-      .sheet()
+      .modifier([.data, .sheet])
       .value(icon.name.rawValue)
     }
   }

--- a/RoutineJournalIconPicker/IconPickerOption/View/IconPickerOption.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/View/IconPickerOption.swift
@@ -69,7 +69,7 @@ struct IconPickerOption_Previews: PreviewProvider {
         }
       }
       .id(IconPickerOption_Previews.name)
-      .sheet()
+      .modifier(.sheet)
       .value(icon.name.rawValue)
     }
 

--- a/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/View/IconPickerOptions.swift
@@ -72,10 +72,8 @@ struct IconPickerOptions_Previews: PreviewProvider {
           }
       }
       .id(IconPickerOptions_Previews.name)
-      .data()
-      .sheet()
-      .value(icon.name.rawValue)
-      .value(query)
+      .modifier([.data, .sheet])
+      .value([icon.name.rawValue, query])
     }
   }
 

--- a/RoutineJournalUI/PreviewContext/PreviewContext+Model.swift
+++ b/RoutineJournalUI/PreviewContext/PreviewContext+Model.swift
@@ -38,8 +38,22 @@ extension PreviewContext {
       return self
     }
 
+    public func reinit(modifiers: [Modifier]) -> Self {
+      modifiers.forEach { modifier in
+        self.modifiers.insert(modifier)
+      }
+      return self
+    }
+
     public func reinit(value: String?) -> Self {
       values.append(value)
+      return self
+    }
+
+    public func reinit(values: [String?]) -> Self {
+      values.forEach { value in
+        self.values.append(value)
+      }
       return self
     }
   }

--- a/RoutineJournalUI/PreviewContext/PreviewContext.swift
+++ b/RoutineJournalUI/PreviewContext/PreviewContext.swift
@@ -64,23 +64,23 @@ public struct PreviewContext<Content>: View where Content: View {
     return reinit(model: model)
   }
 
-  public func data() -> Self {
-    let model = model.reinit(modifier: .data)
+  public func modifier(_ modifier: Modifier) -> Self {
+    let model = model.reinit(modifier: modifier)
     return reinit(model: model)
   }
 
-  public func sheet() -> Self {
-    let model = model.reinit(modifier: .sheet)
-    return reinit(model: model)
-  }
-
-  public func counter() -> Self {
-    let model = model.reinit(modifier: .counter)
+  public func modifier(_ modifiers: [Modifier]) -> Self {
+    let model = model.reinit(modifiers: modifiers)
     return reinit(model: model)
   }
 
   public func value(_ value: String?) -> Self {
     let model = model.reinit(value: value)
+    return reinit(model: model)
+  }
+
+  public func value(_ values: [String?]) -> Self {
+    let model = model.reinit(values: values)
     return reinit(model: model)
   }
 }
@@ -133,9 +133,7 @@ struct PreviewContext_Previews: PreviewProvider {
       }
       .id(PreviewContext_Previews.name)
       .position(.top, .leading)
-      .data()
-      .sheet()
-      .counter()
+      .modifier([.counter, .data, .sheet])
       .value("\(model.count) (\(model.type.description()))")
     }
   }


### PR DESCRIPTION
- Simplify `PreviewContext` `modifiers` and `values`
- Replace `PreviewContext` `modifiers` in `RoutineJournal` to the new version
- Replace `PreviewContext` `modifiers` in `AppearanceSection` to the new version
- Replace `PreviewContext` `modifiers` in `CategoryForm` to the new version
- Replace `PreviewContext` `modifiers` and `values` in `CategoryPicker` to the new version
- Replace `PreviewContext` `modifiers` in `EventForm` to the new version
- Replace `PreviewContext` `modifiers` and `values` in `IconPicker` to the new version
- Replace `PreviewContext` `modifiers` in `HomeView` to the new version
