### PR TITLE
Rename `OnSelectModifier` to `SelectionModifier`

### DIFF
--- a/RoutineJournalCategoryPicker/CategoryPickerOption/Intent/CategoryPickerOptionIntent.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOption/Intent/CategoryPickerOptionIntent.swift
@@ -1,6 +1,6 @@
-import RoutineJournalOnSelectModifier
+import RoutineJournalSelectionModifier
 
-public final class CategoryPickerOptionIntent: OnSelectModifier {
+public final class CategoryPickerOptionIntent: SelectionModifier {
   public typealias Model = CategoryPickerOptionModel
 
   public weak var model: Model?

--- a/RoutineJournalCategoryPicker/CategoryPickerOption/Intent/CategoryPickerOptionIntent.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOption/Intent/CategoryPickerOptionIntent.swift
@@ -4,12 +4,12 @@ public final class CategoryPickerOptionIntent: SelectionModifier {
   public typealias Model = CategoryPickerOptionModel
 
   public weak var model: Model?
-  public var actionOnSelect: (() -> Void)?
+  public var selectionAction: (() -> Void)?
 
   public init() {}
 
   public func onSelect() {
     model?.select()
-    actionOnSelect?()
+    selectionAction?()
   }
 }

--- a/RoutineJournalCategoryPicker/CategoryPickerOptions/Intent/CategoryPickerOptionsIntent.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOptions/Intent/CategoryPickerOptionsIntent.swift
@@ -4,7 +4,7 @@ public final class CategoryPickerOptionsIntent: SelectionModifier {
   public typealias Model = CategoryPickerOptionsModel
 
   public weak var model: Model?
-  public var actionOnSelect: (() -> Void)?
+  public var selectionAction: (() -> Void)?
 
   public init() {}
 }

--- a/RoutineJournalCategoryPicker/CategoryPickerOptions/Intent/CategoryPickerOptionsIntent.swift
+++ b/RoutineJournalCategoryPicker/CategoryPickerOptions/Intent/CategoryPickerOptionsIntent.swift
@@ -1,6 +1,6 @@
-import RoutineJournalOnSelectModifier
+import RoutineJournalSelectionModifier
 
-public final class CategoryPickerOptionsIntent: OnSelectModifier {
+public final class CategoryPickerOptionsIntent: SelectionModifier {
   public typealias Model = CategoryPickerOptionsModel
 
   public weak var model: Model?

--- a/RoutineJournalCategoryPicker/Project.swift
+++ b/RoutineJournalCategoryPicker/Project.swift
@@ -21,7 +21,7 @@ let project = Project(
         .project("RoutineJournalCore"),
         .project("RoutineJournalFoundation"),
         .project("RoutineJournalMVI"),
-        .project("RoutineJournalOnSelectModifier"),
+        .project("RoutineJournalSelectionModifier"),
         .project("RoutineJournalQueryModifier"),
         .project("RoutineJournalUI")
       ]

--- a/RoutineJournalEventForm/EventFormCategorySearchResults/Intent/EventFormCategorySearchResultsIntent.swift
+++ b/RoutineJournalEventForm/EventFormCategorySearchResults/Intent/EventFormCategorySearchResultsIntent.swift
@@ -1,13 +1,13 @@
 import RoutineJournalCore
 
 public final class EventFormCategorySearchResultsIntent {
-  public var actionOnSelect: (CategoryObject) -> Void
+  public var selectionAction: (CategoryObject) -> Void
 
-  public init(actionOnSelect: @escaping (CategoryObject) -> Void = { _ in }) {
-    self.actionOnSelect = actionOnSelect
+  public init(selectionAction: @escaping (CategoryObject) -> Void = { _ in }) {
+    self.selectionAction = selectionAction
   }
 
   public func onSelect(object: CategoryObject) {
-    actionOnSelect(object)
+    selectionAction(object)
   }
 }

--- a/RoutineJournalEventForm/EventFormCategorySearchResults/View/EventFormCategorySearchResultsView.swift
+++ b/RoutineJournalEventForm/EventFormCategorySearchResults/View/EventFormCategorySearchResultsView.swift
@@ -51,7 +51,7 @@ public struct EventFormCategorySearchResultsView: SwiftUI.View {
     perform action: @escaping (CategoryObject) -> Void
   ) -> View {
     let model = Model(objects: model.objects)
-    let intent = Intent(actionOnSelect: action)
+    let intent = Intent(selectionAction: action)
     return View(model: model, intent: intent)
   }
 }

--- a/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
@@ -4,12 +4,12 @@ public final class IconPickerOptionIntent: SelectionModifier {
   public typealias Model = IconPickerOptionModel
 
   public weak var model: Model?
-  public var actionOnSelect: (() -> Void)?
+  public var selectionAction: (() -> Void)?
 
   public init() {}
 
   public func onSelect() {
     model?.select()
-    actionOnSelect?()
+    selectionAction?()
   }
 }

--- a/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOption/Intent/IconPickerOptionIntent.swift
@@ -1,6 +1,6 @@
-import RoutineJournalOnSelectModifier
+import RoutineJournalSelectionModifier
 
-public final class IconPickerOptionIntent: OnSelectModifier {
+public final class IconPickerOptionIntent: SelectionModifier {
   public typealias Model = IconPickerOptionModel
 
   public weak var model: Model?

--- a/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
@@ -1,6 +1,6 @@
-import RoutineJournalOnSelectModifier
+import RoutineJournalSelectionModifier
 
-public final class IconPickerOptionsIntent: OnSelectModifier {
+public final class IconPickerOptionsIntent: SelectionModifier {
   public typealias Model = IconPickerOptionsModel
 
   public weak var model: Model?

--- a/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
+++ b/RoutineJournalIconPicker/IconPickerOptions/Intent/IconPickerOptionsIntent.swift
@@ -4,7 +4,7 @@ public final class IconPickerOptionsIntent: SelectionModifier {
   public typealias Model = IconPickerOptionsModel
 
   public weak var model: Model?
-  public var actionOnSelect: (() -> Void)?
+  public var selectionAction: (() -> Void)?
 
   public init() {}
 }

--- a/RoutineJournalIconPicker/Project.swift
+++ b/RoutineJournalIconPicker/Project.swift
@@ -22,7 +22,7 @@ let project = Project(
         .project("RoutineJournalIconSelectionModifier"),
         .project("RoutineJournalIconView"),
         .project("RoutineJournalMVI"),
-        .project("RoutineJournalOnSelectModifier"),
+        .project("RoutineJournalSelectionModifier"),
         .project("RoutineJournalQueryModifier"),
         .project("RoutineJournalUI")
       ]

--- a/RoutineJournalSelectionModifier/Project.swift
+++ b/RoutineJournalSelectionModifier/Project.swift
@@ -2,17 +2,17 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = Project(
-  name: "RoutineJournalOnSelectModifier",
+  name: "RoutineJournalSelectionModifier",
   targets: [
     Target(
-      name: "RoutineJournalOnSelectModifier",
+      name: "RoutineJournalSelectionModifier",
       platform: .iOS,
       product: .framework,
-      bundleId: "my.vanyauhalin.RoutineJournalOnSelectModifier",
+      bundleId: "my.vanyauhalin.RoutineJournalSelectionModifier",
       deploymentTarget: .iOS(targetVersion: "15.4", devices: .iphone),
       sources: .relative("**/*.swift"),
       scripts: [
-        .lint("RoutineJournalOnSelectModifier")
+        .lint("RoutineJournalSelectionModifier")
       ],
       dependencies: [
         .project("RoutineJournalMVI")

--- a/RoutineJournalSelectionModifier/SelectionModifier/Intent/SelectionModifier.swift
+++ b/RoutineJournalSelectionModifier/SelectionModifier/Intent/SelectionModifier.swift
@@ -1,9 +1,9 @@
 import RoutineJournalMVI
 
 public protocol SelectionModifier: MVIIntent {
-  var actionOnSelect: (() -> Void)? { get set }
+  var selectionAction: (() -> Void)? { get set }
 
-  func reinit(model: Model, actionOnSelect: @escaping () -> Void) -> Self
+  func reinit(model: Model, selectionAction: @escaping () -> Void) -> Self
 
   func onSelect()
 }
@@ -11,14 +11,14 @@ public protocol SelectionModifier: MVIIntent {
 extension SelectionModifier {
   public func reinit(
     model: Model,
-    actionOnSelect: @escaping () -> Void
+    selectionAction: @escaping () -> Void
   ) -> Self {
     let intent = reinit(model: model)
-    intent.actionOnSelect = actionOnSelect
+    intent.selectionAction = selectionAction
     return intent
   }
 
   public func onSelect() {
-    actionOnSelect?()
+    selectionAction?()
   }
 }

--- a/RoutineJournalSelectionModifier/SelectionModifier/Intent/SelectionModifier.swift
+++ b/RoutineJournalSelectionModifier/SelectionModifier/Intent/SelectionModifier.swift
@@ -1,6 +1,6 @@
 import RoutineJournalMVI
 
-public protocol OnSelectModifier: MVIIntent {
+public protocol SelectionModifier: MVIIntent {
   var actionOnSelect: (() -> Void)? { get set }
 
   func reinit(model: Model, actionOnSelect: @escaping () -> Void) -> Self
@@ -8,7 +8,7 @@ public protocol OnSelectModifier: MVIIntent {
   func onSelect()
 }
 
-extension OnSelectModifier {
+extension SelectionModifier {
   public func reinit(
     model: Model,
     actionOnSelect: @escaping () -> Void

--- a/RoutineJournalSelectionModifier/SelectionModifier/View/MVIView+SelectionModifier.swift
+++ b/RoutineJournalSelectionModifier/SelectionModifier/View/MVIView+SelectionModifier.swift
@@ -1,6 +1,6 @@
 import RoutineJournalMVI
 
-extension MVIView where Intent: OnSelectModifier, Intent.Model == Model {
+extension MVIView where Intent: SelectionModifier, Intent.Model == Model {
   public func onSelect(perform action: @escaping () -> Void) -> Self {
     let intent = intent.reinit(model: model, actionOnSelect: action)
     return Self(model: model, intent: intent)

--- a/RoutineJournalSelectionModifier/SelectionModifier/View/MVIView+SelectionModifier.swift
+++ b/RoutineJournalSelectionModifier/SelectionModifier/View/MVIView+SelectionModifier.swift
@@ -2,7 +2,7 @@ import RoutineJournalMVI
 
 extension MVIView where Intent: SelectionModifier, Intent.Model == Model {
   public func onSelect(perform action: @escaping () -> Void) -> Self {
-    let intent = intent.reinit(model: model, actionOnSelect: action)
+    let intent = intent.reinit(model: model, selectionAction: action)
     return Self(model: model, intent: intent)
   }
 }


### PR DESCRIPTION
- Rename `OnSelectModifier` to `SelectionModifier`
- Rename `OnSelectModifier` to `SelectionModifier` in `CategoryPicker` modules
- Rename `OnSelectModifier` to `SelectionModifier` in `IconPicker` modules
- Rename `SelectionModifier` `actionOnSelect` to `selectionAction`
- Rename `SelectionModifier` `actionOnSelect` to `selectionAction` in `CategoryPicker` modules
- Rename `SelectionModifier` `actionOnSelect` to `selectionAction` in `EventForm` modules
- Rename `SelectionModifier` `actionOnSelect` to `selectionAction` in `IconPicker` modules
